### PR TITLE
fixes issue #55 - Dockerfile misconfiguration - incorrect Python and b2sdk versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,22 @@
 #
 # Uses the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7-slim
+FROM python:3.10-slim
 
-# Copy local code to the container image.
+# Install production dependencies: ffmpeg & gunicorn
+RUN apt-get update -y && apt-get install -y ffmpeg && apt-get clean
+RUN pip install --upgrade pip
+RUN pip install gunicorn
+
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . ./
 
 # Install production dependencies.
-RUN pip install b2sdk gunicorn requests webob yt-dlp
-RUN apt-get update -y && apt-get install -y ffmpeg && apt-get clean
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+COPY . ./
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-b2sdk==1.9.0
+b2sdk==2.5.1
 boto==2.49.0
 requests==2.32.3
-WebOb==1.8.7
+WebOb==1.8.8
 yt-dlp>=2024.5.27


### PR DESCRIPTION

Updating the Dockerfile to match the changes in 611fd37

* set python 3.10 as the base image matching the default Python version on Ubuntu 22.
* set b2sdk to the latest version available 2.5.1.
* use  requirements.txt to install the production dependencies.

I also changed the order of the RUN commands in the Dockerfile to save time when rebuilding. 